### PR TITLE
Upgrade from spring-osgi to eclipse virgo version of Manifest utils

### DIFF
--- a/cz.sw.maven.plugins.virgo.plan/pom.xml
+++ b/cz.sw.maven.plugins.virgo.plan/pom.xml
@@ -62,11 +62,11 @@
 			<artifactId>plexus-utils</artifactId>
 			<version>3.0.8</version>
 		</dependency>
-		<dependency>
-			<groupId>com.springsource.util</groupId>
-			<artifactId>com.springsource.util.osgi</artifactId>
-			<version>2.0.5.RELEASE</version>
-		</dependency>
+        <dependency>
+	        <groupId>org.eclipse.virgo.util</groupId>
+	        <artifactId>org.eclipse.virgo.util.osgi.manifest</artifactId>
+	        <version>3.5.0.RELEASE</version>
+        </dependency>
         <dependency>
             <groupId>org.osgi</groupId>
             <artifactId>org.osgi.core</artifactId>


### PR DESCRIPTION
Hi Matej,

Would you mind accepting this pull request please. I have upgraded the version of the Manifest util bundle to be  from eclipse instead of spring.

I also added the ability to override the plan name and put the configuration section at the top so it gets loaded first when being deployed.

Many thanks,

Ron
